### PR TITLE
update flex detection to work w/ version 2.6.0

### DIFF
--- a/config/programs.m4
+++ b/config/programs.m4
@@ -77,7 +77,7 @@ else
         echo '%%'  > conftest.l
         if $pgac_candidate -t conftest.l 2>/dev/null | grep FLEX_SCANNER >/dev/null 2>&1; then
           pgac_flex_version=`$pgac_candidate --version 2>/dev/null`
-          if echo "$pgac_flex_version" | sed ['s/[.a-z]/ /g'] | $AWK '{ if ([$]1 = 2 && [$]2 = 5 && [$]3 >= 31) exit 0; else exit 1;}'
+          if echo "$pgac_flex_version" | sed ['s/[.a-z]/ /g'] | $AWK '{ if ([$]1 = 2 && (([$]2 = 5 && [$]3 >= 31) || [$2] = 6)) exit 0; else exit 1;}'
           then
             pgac_cv_path_flex=$pgac_candidate
             break 2

--- a/configure
+++ b/configure
@@ -7157,7 +7157,7 @@ else
         echo '%%'  > conftest.l
         if $pgac_candidate -t conftest.l 2>/dev/null | grep FLEX_SCANNER >/dev/null 2>&1; then
           pgac_flex_version=`$pgac_candidate --version 2>/dev/null`
-          if echo "$pgac_flex_version" | sed 's/[.a-z]/ /g' | $AWK '{ if ($1 = 2 && $2 = 5 && $3 >= 31) exit 0; else exit 1;}'
+          if echo "$pgac_flex_version" | sed 's/[.a-z]/ /g' | $AWK '{ if ($1 = 2 && (($2 = 5 && $3 >= 31) || $2 = 6)) exit 0; else exit 1;}'
           then
             pgac_cv_path_flex=$pgac_candidate
             break 2


### PR DESCRIPTION
without this patch i get the following error w/ ./configure:

```
checking for flex... configure: WARNING:
*** The installed version of Flex, /usr/bin/flex, is too old to use with PostgreSQL.
*** Flex version 2.5.31 or later is required, but this is flex 2.6.0.
configure: WARNING:
*** The installed version of Flex, /usr/bin/lex, is too old to use with PostgreSQL.
*** Flex version 2.5.31 or later is required, but this is lex 2.6.0.
no
configure: WARNING:
*** Without Flex you will not be able to build PostgreSQL from Git nor
*** change any of the scanner definition files.  You can obtain Flex from
*** a GNU mirror site.  (If you are using the official distribution of
*** PostgreSQL then you do not need to worry about this because the Flex
*** output is pre-generated.)
```

my system:
```sh
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 16.04 LTS
Release:        16.04
Codename:       xenial
$ flex --version
flex 2.6.0
lex --version
lex 2.6.0
```